### PR TITLE
Subscription Payment also looks at renewal orders for mandate.

### DIFF
--- a/src/Subscription/MollieSubscriptionGateway.php
+++ b/src/Subscription/MollieSubscriptionGateway.php
@@ -235,15 +235,30 @@ class MollieSubscriptionGateway extends MolliePaymentGateway
         $subscriptions = wcs_get_subscriptions_for_renewal_order($renewal_order->get_id());
         $subscription = array_pop($subscriptions); // Just need one valid subscription
         $subscription_mollie_payment_id = $subscription->get_meta('_mollie_payment_id');
-        $subcriptionParentOrder = $subscription->get_parent();
-        $mandateId = !empty($subcriptionParentOrder) ? $subcriptionParentOrder->get_meta('_mollie_mandate_id') : null;
+        $subscriptionParentOrder = $subscription->get_parent();
+        $subscriptionRenewalOrders = $subscription->get_related_orders('ids', 'renewal');
+        $mandateId = null;
+
+        // Get the mandate id from the previous Renewal Orders, or when not changed from the parent order.
+	    foreach( $subscriptionRenewalOrders as $renewalOrderId) {
+		    $orderMandate = get_post_meta($renewalOrderId, '_mollie_mandate_id', true);
+
+		    if (! empty($orderMandate)) {
+			    $mandateId = $orderMandate;
+			    break;
+		    }
+	    }
+        
+        if (! $mandateId) {
+		    $mandateId = ! empty($subscriptionParentOrder) ? $subscriptionParentOrder->get_meta('_mollie_mandate_id') : null;
+	    }
 
         if (! empty($subscription_mollie_payment_id) && ! empty($subscription)) {
             $customer_id = $this->restore_mollie_customer_id_and_mandate($customer_id, $subscription_mollie_payment_id, $subscription);
         }
 
         // Get all data for the renewal payment
-        $initialPaymentUsedOrderAPI = $this->initialPaymentUsedOrderAPI($subcriptionParentOrder);
+        $initialPaymentUsedOrderAPI = $this->initialPaymentUsedOrderAPI($subscriptionParentOrder);
         $data = $this->subscriptionObject->getRecurringPaymentRequestData($renewal_order, $customer_id, $initialPaymentUsedOrderAPI);
 
         // Allow filtering the renewal payment data
@@ -301,14 +316,14 @@ class MollieSubscriptionGateway extends MolliePaymentGateway
                         (property_exists($payment, 'mandateId')
                             && $payment->mandateId !== null)
                         && $payment->mandateId !== $mandateId
-                        && !empty($subcriptionParentOrder)
+                        && !empty($subscriptionParentOrder)
                     ) {
                         $this->logger->debug("{$this->id}: updating to mandate {$payment->mandateId}");
-                        $subcriptionParentOrder->update_meta_data(
+                        $subscriptionParentOrder->update_meta_data(
                             '_mollie_mandate_id',
                             $payment->mandateId
                         );
-                        $subcriptionParentOrder->save();
+                        $subscriptionParentOrder->save();
                         $mandateId = $payment->mandateId;
                     }
                 } else {
@@ -722,15 +737,15 @@ class MollieSubscriptionGateway extends MolliePaymentGateway
     }
 
     /**
-     * @param $subcriptionParentOrder
+     * @param $subscriptionParentOrder
      * @return bool
      */
-    protected function initialPaymentUsedOrderAPI($subcriptionParentOrder): bool
+    protected function initialPaymentUsedOrderAPI($subscriptionParentOrder): bool
     {
-        if (!$subcriptionParentOrder) {
+        if (!$subscriptionParentOrder) {
             return false;
         }
-        $orderIdMeta = $subcriptionParentOrder->get_meta('_mollie_order_id');
+        $orderIdMeta = $subscriptionParentOrder->get_meta('_mollie_order_id');
 
         $parentOrderMeta = $orderIdMeta ?: PaymentService::PAYMENT_METHOD_TYPE_PAYMENT;
 


### PR DESCRIPTION
I've noticed the following scenario:
- Customer pays for subscription initially. 
- A mandate will be given and saved on the parent Order.
- If for some reason the payment fails (this could be the bank just refusing the payment due to more strict authentication nowadays) and requires manual payment, there will be a new mandate within Mollie & within the Renewal Order.
- When renewing the subscription again (after the interval is due again) the newly created mandate won't be used for the latest renewal order payment.
- The old mandate will be used again (which is expired/revoked).

I decided it would be better to also check for mandates on the renewal orders instead of changing the parent order mandate. Since this would remove history of what mandates are used.